### PR TITLE
docs: add comprehensive README with project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,156 @@
-# Slc Ai Tutor App
+# SLC AI Tutor App
 
+AI-powered tutoring application that enables students to practice conversations with AI tutors, receive real-time help, and get graded on their interactions.
 
+## Overview
 
-## Getting started
+This application integrates with [OpenWebUI](https://github.com/open-webui/open-webui) to provide:
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+- **AI Chat Sessions** - Students interact with AI tutors for language/skill practice
+- **Real-time Help** - Students can request contextual help during conversations
+- **Automated Grading** - AI evaluates student performance and provides scores
+- **Staff Dashboard** - Administrators can view all users and their chat histories
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+## Tech Stack
 
-## Add your files
+| Layer | Technology |
+|-------|------------|
+| **Backend** | Django REST Framework, Python 3.10+ |
+| **Frontend** | React 18, Vite, TypeScript |
+| **Auth** | JWT (Simple JWT) |
+| **AI Integration** | OpenWebUI API |
+| **Database** | PostgreSQL |
+| **Web Server** | Caddy |
+| **Containerization** | Docker, Docker Compose |
 
-- [ ] [Create](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://docs.gitlab.com/topics/git/add_files/#add-files-to-a-git-repository) or push an existing Git repository with the following command:
+## Project Structure
 
 ```
-cd existing_repo
-git remote add origin https://gitlab.com/slc-ai/slc-ai-tutor-app.git
-git branch -M main
-git push -uf origin main
+├── backend/                 # Django REST API
+│   ├── api/                # Main API app
+│   │   ├── models.py       # User, Chat, ChatMessage models
+│   │   ├── views.py        # API endpoints
+│   │   ├── serializers.py  # DRF serializers
+│   │   └── urls.py         # URL routing
+│   └── backend/            # Django settings
+├── frontend/               # React application
+│   └── src/
+│       ├── app/
+│       │   ├── pages/      # Route pages
+│       │   ├── components/ # Reusable components
+│       │   ├── services/   # API clients
+│       │   └── store/      # Redux state
+│       └── assets/         # Images, JSON data
+├── caddy/                  # Caddy web server config
+├── docs/                   # Documentation
+│   ├── modernization/      # Modernization planning
+│   └── planning/           # Feature planning
+└── scripts/                # Dev/CI scripts
 ```
 
-## Integrate with your tools
+## Getting Started
 
-- [ ] [Set up project integrations](https://gitlab.com/slc-ai/slc-ai-tutor-app/-/settings/integrations)
+### Prerequisites
 
-## Collaborate with your team
+- Docker & Docker Compose
+- Node.js 18+ (for frontend development)
+- Python 3.10+ (for backend development)
+- OpenWebUI instance (for AI functionality)
 
-- [ ] [Invite team members and collaborators](https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Set auto-merge](https://docs.gitlab.com/user/project/merge_requests/auto_merge/)
+### Development Setup
 
-## Test and Deploy
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/eltanno/slc-ai-tutor-app-modernized.git
+   cd slc-ai-tutor-app-modernized
+   ```
 
-Use the built-in continuous integration in GitLab.
+2. **Copy environment files**
+   ```bash
+   cp .env.example .env
+   cp backend/.env.example backend/.env
+   ```
 
-- [ ] [Get started with GitLab CI/CD](https://docs.gitlab.com/ee/ci/quick_start/)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing (SAST)](https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
+3. **Start the database**
+   ```bash
+   ./start_dev_db.sh
+   ```
 
-***
+4. **Run with Docker Compose**
+   ```bash
+   docker-compose up
+   ```
 
-# Editing this README
+   Or for development:
+   ```bash
+   docker-compose -f docker-compose.dev.yml up
+   ```
 
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!). Thanks to [makeareadme.com](https://www.makeareadme.com/) for this template.
+### Manual Development (without Docker)
 
-## Suggestions for a good README
+**Backend:**
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py runserver
+```
 
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
+**Frontend:**
+```bash
+cd frontend
+npm install
+npm run dev
+```
 
-## Name
-Choose a self-explaining name for your project.
+## API Endpoints
 
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/user/me/` | GET | Get logged-in user |
+| `/api/users/` | GET | List all users (staff only) |
+| `/api/chats/` | GET, POST | List/create chat sessions |
+| `/api/chats/<id>/` | GET, PUT, DELETE | Chat CRUD |
+| `/api/chats/<id>/send-message/` | POST | Send message to AI |
+| `/api/chats/<id>/get-help/` | POST | Request help from AI |
+| `/api/chats/<id>/grade/` | POST | Grade the chat session |
 
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
+## Development Standards
 
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
+This project follows strict development practices:
 
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
+- **TDD** - Tests before implementation
+- **Feature branches** - Never commit to main directly
+- **Conventional commits** - `type(scope): description`
+- **Pre-commit hooks** - Linting enforced on commit
+- **90% test coverage** - Minimum requirement
 
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
+See [docs/modernization/](docs/modernization/) for the modernization roadmap.
 
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
+## Code Quality Tools
 
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
+```bash
+# Python linting
+source .venv/bin/activate
+ruff check . --fix
 
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
+# JavaScript/TypeScript linting
+npx eslint . --fix
 
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
+# Run pre-commit on all files
+pre-commit run --all-files
+```
 
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
+## Modernization Status
 
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
+This codebase is undergoing active modernization. Track progress:
+
+- **Kanban Board**: [GitHub Project](https://github.com/users/eltanno/projects/5)
+- **Assessment**: [docs/modernization/assessment.md](docs/modernization/assessment.md)
+- **Test Plan**: [docs/modernization/characterization-tests.md](docs/modernization/characterization-tests.md)
 
 ## License
-For open source projects, say how it is licensed.
 
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
+Proprietary - All rights reserved.


### PR DESCRIPTION
## Summary

- Replaces default GitLab template README with comprehensive project documentation
- Documents tech stack, project structure, and API endpoints
- Includes getting started guide for Docker and manual development
- Links to Kanban board and modernization docs

## Changes

- Project overview and feature list
- Tech stack table
- Project structure diagram
- Getting started (Docker + manual setup)
- API endpoints reference
- Development standards section
- Modernization status with links

## Test plan

- [ ] Verify all links work
- [ ] Verify getting started instructions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)