### PR TITLE
test: Add E2E dashboard and navigation tests

### DIFF
--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -79,11 +79,11 @@ test.describe('Authentication', () => {
     // Should be on dashboard
     await expect(page).toHaveURL(/\/dashboard/);
 
-    // Close welcome dialog if it appears
-    const closeButton = page.getByRole('button', { name: 'close' });
-    if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await closeButton.click();
-    }
+    // Welcome dialog always appears on first dashboard visit - wait for it and close it
+    const welcomeDialog = page.getByRole('dialog', { name: 'Welcome to the site!' });
+    await expect(welcomeDialog).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'close' }).click();
+    await expect(welcomeDialog).not.toBeVisible({ timeout: 5000 });
 
     // Dashboard should show app header (MUI Button with Link component has role=link)
     await expect(page.getByRole('link', { name: 'SLC AI Demo App' })).toBeVisible({ timeout: 10000 });
@@ -99,11 +99,11 @@ test.describe('Authentication', () => {
     // Wait for dashboard
     await expect(page).toHaveURL(/\/dashboard/);
 
-    // Close welcome dialog if it appears
-    const closeButton = page.getByRole('button', { name: 'close' });
-    if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await closeButton.click();
-    }
+    // Welcome dialog always appears on first dashboard visit - wait for it and close it
+    const welcomeDialog = page.getByRole('dialog', { name: 'Welcome to the site!' });
+    await expect(welcomeDialog).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'close' }).click();
+    await expect(welcomeDialog).not.toBeVisible({ timeout: 5000 });
 
     // Click logout (MUI Button with Link component has role=link)
     await page.getByRole('link', { name: 'Log out' }).click();

--- a/frontend/tests/e2e/dashboard.spec.ts
+++ b/frontend/tests/e2e/dashboard.spec.ts
@@ -1,22 +1,52 @@
-import { test } from '@playwright/test';
-
-// Issue #24: E2E Dashboard & Navigation tests (4 tests)
-// These tests will be implemented in feature/issue-24-dashboard-tests
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './fixtures/test-data';
 
 test.describe('Dashboard & Navigation', () => {
-  test.skip('should display dashboard with navigation sidebar', async () => {
-    // TODO: Implement in issue #24
+  test.beforeEach(async ({ page }) => {
+    // Login before each test
+    await page.goto('/login');
+    await page.getByLabel('Email Address').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    // Welcome dialog always appears on first dashboard visit - wait for it and close it
+    const welcomeDialog = page.getByRole('dialog', { name: 'Welcome to the site!' });
+    await expect(welcomeDialog).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'close' }).click();
+    await expect(welcomeDialog).not.toBeVisible({ timeout: 5000 });
   });
 
-  test.skip('should show user info in header/sidebar', async () => {
-    // TODO: Implement in issue #24
+  test('should display training units with scenario cards', async ({ page }) => {
+    // Check Training Scenarios heading
+    await expect(page.getByRole('heading', { name: 'Training Scenarios' })).toBeVisible();
+
+    // Check that units are displayed
+    await expect(page.getByRole('heading', { name: /Unit 1:/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Unit 2:/ })).toBeVisible();
+
+    // Check that scenario cards exist (at least one persona name)
+    await expect(page.getByText('Mrs Jameson')).toBeVisible();
   });
 
-  test.skip('should navigate between main sections', async () => {
-    // TODO: Implement in issue #24
+  test('should show welcome message with user email', async ({ page }) => {
+    // Check welcome heading contains user email
+    await expect(page.getByRole('heading', { name: new RegExp(`Welcome.*${TEST_USER.email}`, 'i') })).toBeVisible();
   });
 
-  test.skip('should display recent chats or empty state', async () => {
-    // TODO: Implement in issue #24
+  test('should navigate to chats page', async ({ page }) => {
+    // Click Chats link in navigation
+    await page.getByRole('link', { name: 'Chats' }).click();
+
+    // Should be on chats page
+    await expect(page).toHaveURL(/\/chats/);
+  });
+
+  test('should navigate to avatar select page', async ({ page }) => {
+    // Click Avatar Select link in navigation
+    await page.getByRole('link', { name: 'Avatar Select' }).click();
+
+    // Should be on avatar select page
+    await expect(page).toHaveURL(/\/avatar-select/);
   });
 });


### PR DESCRIPTION
## Summary
- Add 4 E2E tests for dashboard functionality and navigation
- Fix dialog race condition that caused intermittent test failures when running in parallel
- Tests now reliably wait for welcome dialog before interacting with dashboard

## Test Coverage Added
- Dashboard displays training units with scenario cards
- Dashboard shows welcome message with user email
- Navigation to Chats page works
- Navigation to Avatar Select page works

## Technical Details
- Dialog handling improved: instead of checking if visible with short timeout, now explicitly wait for dialog to appear (it always appears on first visit) then close it
- Applied same fix to auth tests to prevent race conditions when running full suite

## Test Results
```
Running 48 tests using 4 workers
  38 skipped (skeleton tests)
  10 passed (31.4s)
```

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)