### PR TITLE
test: set up Vitest infrastructure for unit tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug"
@@ -33,6 +36,9 @@
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@playwright/test": "^1.57.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
@@ -41,8 +47,11 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^24.1.3",
+    "msw": "^2.12.7",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^4.0.16"
   }
 }

--- a/frontend/src/test/setup.test.ts
+++ b/frontend/src/test/setup.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+describe('Vitest Setup', () => {
+  it('should run a basic test', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  it('should have jest-dom matchers available', () => {
+    const div = document.createElement('div');
+    div.textContent = 'Hello';
+    document.body.appendChild(div);
+
+    expect(div).toBeInTheDocument();
+    expect(div).toHaveTextContent('Hello');
+
+    document.body.removeChild(div);
+  });
+
+  it('should have window.matchMedia mocked', () => {
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    expect(mediaQuery.matches).toBe(false);
+    expect(mediaQuery.media).toBe('(min-width: 768px)');
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom';
+
+// Mock window.matchMedia for MUI components
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+// Mock ResizeObserver for components that use it
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Mock IntersectionObserver
+global.IntersectionObserver = class IntersectionObserver {
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'src/test/'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Set up Vitest testing infrastructure for unit and component tests
- Install all required testing dependencies
- Configure jsdom environment with browser API mocks
- Add npm scripts for running unit tests

## Changes
- `frontend/package.json`: Added test dependencies and scripts
- `frontend/vitest.config.ts`: Vitest configuration
- `frontend/src/test/setup.ts`: Test setup with jest-dom and mocks
- `frontend/src/test/setup.test.ts`: Verification test

## Test plan
- [x] Run `npm run test:run` - all 3 verification tests pass

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)