### PR TITLE
test: add unit tests for avatar and chat metadata lookup utils

### DIFF
--- a/frontend/tests/unit/utils/getAvatarById.test.ts
+++ b/frontend/tests/unit/utils/getAvatarById.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getAvatarById,
+  AVATAR_LIST,
+  type UserAvatar,
+} from '../../../src/app/utils/getAvatarById';
+
+describe('getAvatarById', () => {
+  it('should return avatar for valid id "1"', () => {
+    const result = getAvatarById('1');
+
+    expect(result).toBeDefined();
+    expect(result?.id).toBe('1');
+    expect(result?.label).toBe('Carer 1');
+  });
+
+  it('should return undefined for invalid id "999"', () => {
+    const result = getAvatarById('999');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should handle string ids correctly', () => {
+    // Test various string IDs
+    const avatar5 = getAvatarById('5');
+    const avatar15 = getAvatarById('15');
+    const avatar25 = getAvatarById('25');
+
+    expect(avatar5?.id).toBe('5');
+    expect(avatar5?.label).toBe('Carer 5');
+
+    expect(avatar15?.id).toBe('15');
+    expect(avatar15?.label).toBe('Tutor 1');
+
+    expect(avatar25?.id).toBe('25');
+    expect(avatar25?.label).toBe('Resident 12');
+  });
+});
+
+describe('AVATAR_LIST', () => {
+  it('should contain all 25 avatars', () => {
+    expect(AVATAR_LIST).toHaveLength(25);
+  });
+
+  it('should have unique ids for all avatars', () => {
+    const ids = AVATAR_LIST.map((avatar: UserAvatar) => avatar.id);
+    const uniqueIds = new Set(ids);
+
+    expect(uniqueIds.size).toBe(AVATAR_LIST.length);
+  });
+
+  it('should have required properties for each avatar', () => {
+    for (const avatar of AVATAR_LIST) {
+      expect(avatar.id).toBeDefined();
+      expect(avatar.src).toBeDefined();
+      expect(avatar.label).toBeDefined();
+    }
+  });
+});

--- a/frontend/tests/unit/utils/getChatMetadataById.test.ts
+++ b/frontend/tests/unit/utils/getChatMetadataById.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getChatMetadataById,
+  CHAT_METADATA_LIST,
+  type ChatMetadata,
+} from '../../../src/app/utils/getChatMetadataById';
+
+describe('getChatMetadataById', () => {
+  it('should return metadata for valid id', () => {
+    const result = getChatMetadataById('unit1_conversation1');
+
+    expect(result).toBeDefined();
+    expect(result?.id).toBe('unit1_conversation1');
+    expect(result?.unit).toBe('Introducing yourself and welcoming service users');
+  });
+
+  it('should return undefined for invalid id', () => {
+    const result = getChatMetadataById('nonexistent_conversation');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for undefined input', () => {
+    const result = getChatMetadataById(undefined);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should find different conversations correctly', () => {
+    const unit2conv1 = getChatMetadataById('unit2_conversation1');
+    const unit4conv2 = getChatMetadataById('unit4_conversation2');
+
+    expect(unit2conv1).toBeDefined();
+    expect(unit2conv1?.id).toBe('unit2_conversation1');
+
+    expect(unit4conv2).toBeDefined();
+    expect(unit4conv2?.id).toBe('unit4_conversation2');
+  });
+});
+
+describe('CHAT_METADATA_LIST', () => {
+  it('should contain all 13 conversations', () => {
+    expect(CHAT_METADATA_LIST).toHaveLength(13);
+  });
+
+  it('should have unique ids for all conversations', () => {
+    const ids = CHAT_METADATA_LIST.map((chat: ChatMetadata) => chat.id);
+    const uniqueIds = new Set(ids);
+
+    expect(uniqueIds.size).toBe(CHAT_METADATA_LIST.length);
+  });
+
+  it('should have required properties for each conversation', () => {
+    for (const chat of CHAT_METADATA_LIST) {
+      expect(chat.id).toBeDefined();
+      expect(chat.model).toBeDefined();
+      expect(chat.unit).toBeDefined();
+      expect(chat.intro).toBeDefined();
+      expect(chat.avatar_id).toBeDefined();
+      expect(chat.resident).toBeDefined();
+    }
+  });
+
+  it('should include conversations from all units', () => {
+    const units = CHAT_METADATA_LIST.map((chat: ChatMetadata) => chat.id.split('_')[0]);
+    const uniqueUnits = new Set(units);
+
+    // Should have unit1 through unit8
+    expect(uniqueUnits.has('unit1')).toBe(true);
+    expect(uniqueUnits.has('unit2')).toBe(true);
+    expect(uniqueUnits.has('unit3')).toBe(true);
+    expect(uniqueUnits.has('unit4')).toBe(true);
+    expect(uniqueUnits.has('unit5')).toBe(true);
+    expect(uniqueUnits.has('unit6')).toBe(true);
+    expect(uniqueUnits.has('unit7')).toBe(true);
+    expect(uniqueUnits.has('unit8')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 6 tests for `getAvatarById.ts` (avatar lookup utility)
- Add 8 tests for `getChatMetadataById.ts` (chat metadata lookup utility)

## Tests Added

### getAvatarById.test.ts
| Test | Description |
|------|-------------|
| `returns_avatar_for_valid_id` | ID "1" returns first avatar |
| `returns_undefined_for_invalid_id` | ID "999" returns undefined |
| `handles_string_ids` | Various string IDs work correctly |
| `AVATAR_LIST_contains_all_avatars` | List has 25 avatars |
| `AVATAR_LIST_has_unique_ids` | No duplicate IDs |
| `AVATAR_LIST_has_required_properties` | All avatars have id, src, label |

### getChatMetadataById.test.ts
| Test | Description |
|------|-------------|
| `returns_metadata_for_valid_id` | Returns matching chat config |
| `returns_undefined_for_invalid_id` | Unknown ID returns undefined |
| `handles_undefined_input` | undefined input returns undefined |
| `finds_different_conversations` | Multiple lookups work |
| `CHAT_METADATA_LIST_contains_all_conversations` | List has 13 conversations |
| `CHAT_METADATA_LIST_has_unique_ids` | No duplicate IDs |
| `CHAT_METADATA_LIST_has_required_properties` | All have required fields |
| `CHAT_METADATA_LIST_includes_all_units` | Units 1-8 present |

Closes #35

## Test plan
- [x] All 33 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)