### PR TITLE
test: add unit tests for Redux preferences slice

### DIFF
--- a/frontend/tests/unit/store/preferences.slice.test.ts
+++ b/frontend/tests/unit/store/preferences.slice.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import preferencesReducer, {
+  setUserAvatarId,
+  setApiToken,
+  setRefreshToken,
+  setSeenDialog,
+  setChatSettings,
+  resetState,
+  getUserAvatarId,
+  getUserAvatar,
+  getApiToken,
+  getRefreshToken,
+  getChatSettings,
+  getSeenDialogs,
+  type PreferencesState,
+} from '../../../src/app/store/preferences.slice';
+
+// Helper to create initial state
+const createInitialState = (): PreferencesState => ({
+  userAvatarId: '1',
+  apiToken: undefined,
+  refreshToken: undefined,
+  seenDialogs: { welcome: false },
+  chatSettings: undefined,
+});
+
+// Helper to create mock RootState for selector tests
+const createMockRootState = (preferences: PreferencesState) => ({
+  preferences,
+  // Add minimal mock for other slices if needed
+  api: {},
+  llmApi: {},
+});
+
+describe('preferences slice reducers', () => {
+  it('setUserAvatarId should update userAvatarId', () => {
+    const initialState = createInitialState();
+    const newState = preferencesReducer(initialState, setUserAvatarId('5'));
+
+    expect(newState.userAvatarId).toBe('5');
+  });
+
+  it('setApiToken should store token', () => {
+    const initialState = createInitialState();
+    const newState = preferencesReducer(initialState, setApiToken('test-token-123'));
+
+    expect(newState.apiToken).toBe('test-token-123');
+  });
+
+  it('setRefreshToken should store refresh token', () => {
+    const initialState = createInitialState();
+    const newState = preferencesReducer(initialState, setRefreshToken('refresh-token-456'));
+
+    expect(newState.refreshToken).toBe('refresh-token-456');
+  });
+
+  it('setSeenDialog should mark dialog as seen', () => {
+    const initialState = createInitialState();
+    const newState = preferencesReducer(
+      initialState,
+      setSeenDialog({ dialogId: 'welcome', seen: true })
+    );
+
+    expect(newState.seenDialogs.welcome).toBe(true);
+  });
+
+  it('setSeenDialog should handle new dialog ids', () => {
+    const initialState = createInitialState();
+    const newState = preferencesReducer(
+      initialState,
+      setSeenDialog({ dialogId: 'tutorial', seen: true })
+    );
+
+    expect(newState.seenDialogs.tutorial).toBe(true);
+    expect(newState.seenDialogs.welcome).toBe(false); // Original unchanged
+  });
+
+  it('setChatSettings should store chat settings', () => {
+    const initialState = createInitialState();
+    const chatSettings = { botAvatarId: '10', llmModel: 'gpt-4' };
+    const newState = preferencesReducer(initialState, setChatSettings(chatSettings));
+
+    expect(newState.chatSettings).toEqual(chatSettings);
+    expect(newState.chatSettings?.botAvatarId).toBe('10');
+    expect(newState.chatSettings?.llmModel).toBe('gpt-4');
+  });
+
+  it('resetState should restore initial state', () => {
+    // Start with modified state
+    const modifiedState: PreferencesState = {
+      userAvatarId: '15',
+      apiToken: 'some-token',
+      refreshToken: 'some-refresh-token',
+      seenDialogs: { welcome: true, tutorial: true },
+      chatSettings: { botAvatarId: '5', llmModel: 'claude' },
+    };
+
+    const newState = preferencesReducer(modifiedState, resetState());
+
+    expect(newState.userAvatarId).toBe('1');
+    expect(newState.apiToken).toBeUndefined();
+    expect(newState.refreshToken).toBeUndefined();
+    expect(newState.seenDialogs).toEqual({ welcome: false });
+    expect(newState.chatSettings).toBeUndefined();
+  });
+});
+
+describe('preferences slice selectors', () => {
+  it('getUserAvatarId should return avatar id', () => {
+    const state = createMockRootState({
+      ...createInitialState(),
+      userAvatarId: '7',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getUserAvatarId(state as any)).toBe('7');
+  });
+
+  it('getUserAvatar should return avatar object', () => {
+    const state = createMockRootState({
+      ...createInitialState(),
+      userAvatarId: '1',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const avatar = getUserAvatar(state as any);
+
+    expect(avatar).toBeDefined();
+    expect(avatar?.id).toBe('1');
+    expect(avatar?.label).toBe('Carer 1');
+  });
+
+  it('getApiToken should return token', () => {
+    const state = createMockRootState({
+      ...createInitialState(),
+      apiToken: 'my-api-token',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getApiToken(state as any)).toBe('my-api-token');
+  });
+
+  it('getRefreshToken should return refresh token', () => {
+    const state = createMockRootState({
+      ...createInitialState(),
+      refreshToken: 'my-refresh-token',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getRefreshToken(state as any)).toBe('my-refresh-token');
+  });
+
+  it('getSeenDialogs should return dialogs object', () => {
+    const state = createMockRootState({
+      ...createInitialState(),
+      seenDialogs: { welcome: true, intro: false },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dialogs = getSeenDialogs(state as any);
+
+    expect(dialogs.welcome).toBe(true);
+    expect(dialogs.intro).toBe(false);
+  });
+
+  it('getChatSettings should return chat settings', () => {
+    const chatSettings = { botAvatarId: '12', llmModel: 'llama' };
+    const state = createMockRootState({
+      ...createInitialState(),
+      chatSettings,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getChatSettings(state as any)).toEqual(chatSettings);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 13 unit tests for Redux preferences slice
- Tests cover all reducers and selectors

## Tests Added

### Reducer Tests (7)
| Test | Description |
|------|-------------|
| `setUserAvatarId_updates_state` | Action updates userAvatarId |
| `setApiToken_stores_token` | Token stored in state |
| `setRefreshToken_stores_token` | Refresh token stored |
| `setSeenDialog_marks_dialog_seen` | Dialog marked as seen |
| `setSeenDialog_handles_new_dialog_ids` | New dialog ids added |
| `setChatSettings_stores_settings` | Chat settings persisted |
| `resetState_clears_all_preferences` | Reset returns to initial state |

### Selector Tests (6)
| Test | Description |
|------|-------------|
| `getUserAvatarId_returns_avatar_id` | Returns avatar ID string |
| `getUserAvatar_returns_avatar_object` | Looks up full avatar object |
| `getApiToken_returns_token` | Returns API token |
| `getRefreshToken_returns_refresh_token` | Returns refresh token |
| `getSeenDialogs_returns_dialogs_object` | Returns dialogs state |
| `getChatSettings_returns_chat_settings` | Returns chat settings |

Closes #36

## Test plan
- [x] All 46 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)