### PR TITLE
test: add component tests for GradingResults, ForceLogin, and GradingResultsModal

### DIFF
--- a/frontend/tests/unit/components/force-login/ForceLogin.test.tsx
+++ b/frontend/tests/unit/components/force-login/ForceLogin.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import ForceLogin from '../../../../src/app/components/force-login/ForceLogin';
+
+// Mock jwt-decode
+vi.mock('jwt-decode', () => ({
+  jwtDecode: vi.fn(),
+}));
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock Auth.api
+const mockRefreshToken = vi.fn();
+vi.mock('../../../../src/app/services/Auth.api.ts', () => ({
+  useRefreshTokenMutation: () => [mockRefreshToken],
+}));
+
+// Mock usePreferences
+const mockSetApiToken = vi.fn();
+const mockSetRefreshToken = vi.fn();
+vi.mock('../../../../src/app/utils/usePreferences.ts', () => ({
+  default: vi.fn(),
+}));
+
+import { jwtDecode } from 'jwt-decode';
+import usePreferences from '../../../../src/app/utils/usePreferences';
+
+describe('ForceLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    mockSetApiToken.mockClear();
+    mockSetRefreshToken.mockClear();
+    mockRefreshToken.mockClear();
+  });
+
+  it('should eventually authorize valid tokens', async () => {
+    // Setup: Valid token that hasn't expired
+    const futureTime = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+    vi.mocked(jwtDecode).mockReturnValue({ exp: futureTime });
+    vi.mocked(usePreferences).mockReturnValue({
+      apiToken: 'valid-token',
+      refreshToken: 'refresh-token',
+      setApiToken: mockSetApiToken,
+      setRefreshToken: mockSetRefreshToken,
+      userAvatarId: '1',
+      setUserAvatarId: vi.fn(),
+      seenDialogs: {},
+      setSeenDialog: vi.fn(),
+      chatSettings: undefined,
+      setChatSettings: vi.fn(),
+    });
+
+    render(
+      <ForceLogin>
+        <div>Protected Content</div>
+      </ForceLogin>
+    );
+
+    // Component should eventually authorize and show children
+    await waitFor(() => {
+      expect(screen.getByText('Protected Content')).toBeInTheDocument();
+    });
+  });
+
+  it('should render children when token is valid', async () => {
+    // Setup: Valid token that hasn't expired
+    const futureTime = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+    vi.mocked(jwtDecode).mockReturnValue({ exp: futureTime });
+    vi.mocked(usePreferences).mockReturnValue({
+      apiToken: 'valid-token',
+      refreshToken: 'refresh-token',
+      setApiToken: mockSetApiToken,
+      setRefreshToken: mockSetRefreshToken,
+      userAvatarId: '1',
+      setUserAvatarId: vi.fn(),
+      seenDialogs: {},
+      setSeenDialog: vi.fn(),
+      chatSettings: undefined,
+      setChatSettings: vi.fn(),
+    });
+
+    render(
+      <ForceLogin>
+        <div>Protected Content</div>
+      </ForceLogin>
+    );
+
+    // Wait for auth check to complete
+    await waitFor(() => {
+      expect(screen.getByText('Protected Content')).toBeInTheDocument();
+    });
+  });
+
+  it('should redirect to login when no token exists', async () => {
+    // Setup: No API token
+    vi.mocked(usePreferences).mockReturnValue({
+      apiToken: undefined,
+      refreshToken: undefined,
+      setApiToken: mockSetApiToken,
+      setRefreshToken: mockSetRefreshToken,
+      userAvatarId: '1',
+      setUserAvatarId: vi.fn(),
+      seenDialogs: {},
+      setSeenDialog: vi.fn(),
+      chatSettings: undefined,
+      setChatSettings: vi.fn(),
+    });
+
+    render(
+      <ForceLogin>
+        <div>Protected Content</div>
+      </ForceLogin>
+    );
+
+    // Wait for redirect
+    await waitFor(() => {
+      expect(screen.getByTestId('navigate')).toHaveTextContent('/login');
+    });
+  });
+});

--- a/frontend/tests/unit/components/grading-results-modal/GradingResultsModal.test.tsx
+++ b/frontend/tests/unit/components/grading-results-modal/GradingResultsModal.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GradingResultsModal from '../../../../src/app/components/grading-results-modal/GradingResultsModal';
+import type { ChatGradingResponse } from '../../../../src/app/types/Grading';
+
+// Helper to create valid grading data
+const createMockGrading = (): ChatGradingResponse => ({
+  communication_quality: {
+    empathy_score: 8.5,
+    active_listening_score: 7.5,
+    clarity_score: 9.0,
+    patience_score: 8.0,
+    professionalism_score: 8.5,
+    overall_score: 8.3,
+    comments: 'Good communication overall',
+  },
+  required_disclosures: [
+    { disclosure: 'Patient name', achieved: true, context: 'Correctly asked for name' },
+  ],
+  end_conditions: [
+    { condition: 'Introduced self', completed: true, evidence: 'Said hello and gave name' },
+  ],
+  strengths: ['Good empathy', 'Clear communication'],
+  areas_for_improvement: [
+    { area: 'Active listening', example: 'Interrupted patient', suggestion: 'Let patient finish speaking' },
+  ],
+  overall_summary: 'Overall a good performance with room for improvement.',
+  recommendations: ['Practice active listening'],
+});
+
+describe('GradingResultsModal', () => {
+  it('should return null when grading is null', () => {
+    const { container } = render(
+      <GradingResultsModal open={true} onClose={() => {}} grading={null} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render dialog with title when open with grading data', () => {
+    const grading = createMockGrading();
+
+    render(
+      <GradingResultsModal open={true} onClose={() => {}} grading={grading} />
+    );
+
+    expect(screen.getByText('Your Performance Results')).toBeInTheDocument();
+    // GradingResults component should render the score (may appear multiple times)
+    expect(screen.getAllByText('8.3/10').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should call onClose when close button is clicked', () => {
+    const mockOnClose = vi.fn();
+    const grading = createMockGrading();
+
+    render(
+      <GradingResultsModal open={true} onClose={mockOnClose} grading={grading} />
+    );
+
+    // Click the Close button in DialogActions
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    fireEvent.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onClose when X icon button is clicked', () => {
+    const mockOnClose = vi.fn();
+    const grading = createMockGrading();
+
+    render(
+      <GradingResultsModal open={true} onClose={mockOnClose} grading={grading} />
+    );
+
+    // Click the X icon button in the title
+    const closeIconButton = screen.getByRole('button', { name: 'close' });
+    fireEvent.click(closeIconButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/unit/components/grading-results/GradingResults.test.tsx
+++ b/frontend/tests/unit/components/grading-results/GradingResults.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GradingResults from '../../../../src/app/components/grading-results/GradingResults';
+import type { ChatGradingResponse } from '../../../../src/app/types/Grading';
+
+// Helper to create valid grading data
+const createMockGrading = (overrides: Partial<ChatGradingResponse> = {}): ChatGradingResponse => ({
+  communication_quality: {
+    empathy_score: 8.5,
+    active_listening_score: 7.5,
+    clarity_score: 9.0,
+    patience_score: 8.0,
+    professionalism_score: 8.5,
+    overall_score: 8.3,
+    comments: 'Good communication overall',
+  },
+  required_disclosures: [
+    { disclosure: 'Patient name', achieved: true, context: 'Correctly asked for name' },
+    { disclosure: 'Symptoms', achieved: false, context: 'Did not ask about symptoms' },
+  ],
+  end_conditions: [
+    { condition: 'Introduced self', completed: true, evidence: 'Said hello and gave name' },
+  ],
+  strengths: ['Good empathy', 'Clear communication'],
+  areas_for_improvement: [
+    { area: 'Active listening', example: 'Interrupted patient', suggestion: 'Let patient finish speaking' },
+  ],
+  overall_summary: 'Overall a good performance with room for improvement.',
+  recommendations: ['Practice active listening', 'Ask more open questions'],
+  ...overrides,
+});
+
+describe('GradingResults', () => {
+  it('should render overall score prominently', () => {
+    const grading = createMockGrading();
+    render(<GradingResults grading={grading} />);
+
+    // Score should appear multiple times (header and communication quality section)
+    expect(screen.getAllByText('8.3/10').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render category breakdown scores', () => {
+    const grading = createMockGrading();
+    render(<GradingResults grading={grading} />);
+
+    expect(screen.getByText('Empathy')).toBeInTheDocument();
+    // Scores may appear multiple times (in header and breakdown), use getAllByText
+    expect(screen.getAllByText('8.5/10').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Active Listening')).toBeInTheDocument();
+    expect(screen.getAllByText('7.5/10').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Clarity')).toBeInTheDocument();
+    expect(screen.getAllByText('9.0/10').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render feedback text (overall summary)', () => {
+    const grading = createMockGrading();
+    render(<GradingResults grading={grading} />);
+
+    expect(screen.getByText('Overall a good performance with room for improvement.')).toBeInTheDocument();
+  });
+
+  it('should render strengths list', () => {
+    const grading = createMockGrading();
+    render(<GradingResults grading={grading} />);
+
+    expect(screen.getByText('Strengths')).toBeInTheDocument();
+    expect(screen.getByText('Good empathy')).toBeInTheDocument();
+    expect(screen.getByText('Clear communication')).toBeInTheDocument();
+  });
+
+  it('should render areas for improvement', () => {
+    const grading = createMockGrading();
+    render(<GradingResults grading={grading} />);
+
+    expect(screen.getByText('Areas for Improvement')).toBeInTheDocument();
+    expect(screen.getByText('Active listening')).toBeInTheDocument();
+  });
+
+  it('should render required disclosures when present', () => {
+    const grading = createMockGrading();
+    render(<GradingResults grading={grading} />);
+
+    expect(screen.getByText('Required Information Gathered')).toBeInTheDocument();
+    expect(screen.getByText('Patient name')).toBeInTheDocument();
+    expect(screen.getByText('Symptoms')).toBeInTheDocument();
+  });
+
+  it('should render recommendations as chips', () => {
+    const grading = createMockGrading();
+    render(<GradingResults grading={grading} />);
+
+    expect(screen.getByText('Recommendations for Next Time')).toBeInTheDocument();
+    expect(screen.getByText('Practice active listening')).toBeInTheDocument();
+    expect(screen.getByText('Ask more open questions')).toBeInTheDocument();
+  });
+
+  it('should handle missing optional fields gracefully', () => {
+    const grading = createMockGrading({
+      required_disclosures: [],
+      end_conditions: [],
+      recommendations: [],
+    });
+
+    render(<GradingResults grading={grading} />);
+
+    // Should still render without crashing
+    // Score may appear multiple times
+    expect(screen.getAllByText('8.3/10').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Strengths')).toBeInTheDocument();
+  });
+
+  it('should show error alert for invalid grading data', () => {
+    // @ts-expect-error - testing invalid data
+    render(<GradingResults grading={null} />);
+
+    expect(screen.getByText(/Invalid grading data/)).toBeInTheDocument();
+  });
+
+  it('should show error alert when communication_quality is missing', () => {
+    const invalidGrading = {
+      strengths: [],
+      areas_for_improvement: [],
+      overall_summary: 'test',
+      recommendations: [],
+      required_disclosures: [],
+      end_conditions: [],
+    } as unknown as ChatGradingResponse;
+
+    render(<GradingResults grading={invalidGrading} />);
+
+    expect(screen.getByText(/Invalid grading data/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 17 unit tests for grading and auth-related components
- Tests cover GradingResults (10 tests), ForceLogin (3 tests), and GradingResultsModal (4 tests)
- All 78 unit tests now passing

## Test plan
- [x] Run `npm test` in frontend/ to verify all tests pass
- [x] Verify test coverage for score display, error handling, auth flow

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)