### PR TITLE
test: add component tests for AvatarImg and TutorDialogModal

### DIFF
--- a/frontend/tests/unit/components/avatar-img/AvatarImg.test.tsx
+++ b/frontend/tests/unit/components/avatar-img/AvatarImg.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AvatarImg from '../../../../src/app/components/avatar-img/AvatarImg';
+
+describe('AvatarImg', () => {
+  it('should render image with correct src for valid avatar id', () => {
+    render(<AvatarImg avatarId="1" />);
+
+    const img = screen.getByRole('img');
+    expect(img).toBeInTheDocument();
+    // Avatar 1 should have a valid src (Carer 1)
+    expect(img).toHaveAttribute('src');
+    expect(img.getAttribute('src')).not.toBe('');
+    expect(img).toHaveAttribute('alt', 'Carer 1');
+  });
+
+  it('should apply size prop to width and height', () => {
+    render(<AvatarImg avatarId="1" size={50} />);
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveStyle({ width: '50px', height: '50px' });
+  });
+
+  it('should use default size of 100 when not specified', () => {
+    render(<AvatarImg avatarId="1" />);
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveStyle({ width: '100px', height: '100px' });
+  });
+
+  it('should handle missing avatar gracefully with fallback', () => {
+    render(<AvatarImg avatarId="invalid-id-99999" />);
+
+    const img = screen.getByRole('img');
+    expect(img).toBeInTheDocument();
+    // Should have 'Avatar' as fallback alt text for unknown avatar
+    expect(img).toHaveAttribute('alt', 'Avatar');
+    // The src may be empty or null depending on how React handles it
+    const src = img.getAttribute('src');
+    expect(src === '' || src === null).toBe(true);
+  });
+
+  it('should apply rotateY transform when direction is right', () => {
+    render(<AvatarImg avatarId="1" direction="right" />);
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveStyle({ transform: 'rotateY(180deg)' });
+  });
+
+  it('should not apply transform when direction is left (default)', () => {
+    render(<AvatarImg avatarId="1" direction="left" />);
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveStyle({ transform: 'none' });
+  });
+});

--- a/frontend/tests/unit/components/tutor-dialog-modal/TutorDialogModal.test.tsx
+++ b/frontend/tests/unit/components/tutor-dialog-modal/TutorDialogModal.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TutorDialogModal from '../../../../src/app/components/tutor-dialog-modal/TutorDialogModal';
+
+describe('TutorDialogModal', () => {
+  const defaultProps = {
+    open: true,
+    handleClose: vi.fn(),
+    title: 'Test Dialog Title',
+    message: 'This is a test message',
+  };
+
+  it('should render dialog with title when open', () => {
+    render(<TutorDialogModal {...defaultProps} />);
+
+    expect(screen.getByText('Test Dialog Title')).toBeInTheDocument();
+  });
+
+  it('should render message content via ChatMessageBox', () => {
+    render(<TutorDialogModal {...defaultProps} />);
+
+    expect(screen.getByText('This is a test message')).toBeInTheDocument();
+  });
+
+  it('should call handleClose when close button is clicked', () => {
+    const handleClose = vi.fn();
+    render(<TutorDialogModal {...defaultProps} handleClose={handleClose} />);
+
+    const closeButton = screen.getByRole('button', { name: 'close' });
+    fireEvent.click(closeButton);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not render when open is false', () => {
+    render(<TutorDialogModal {...defaultProps} open={false} />);
+
+    // Dialog content should not be visible
+    expect(screen.queryByText('Test Dialog Title')).not.toBeInTheDocument();
+  });
+
+  it('should render actions when provided', () => {
+    render(
+      <TutorDialogModal
+        {...defaultProps}
+        actions={<button>Custom Action</button>}
+      />
+    );
+
+    expect(screen.getByText('Custom Action')).toBeInTheDocument();
+  });
+
+  it('should not render actions section when actions prop is not provided', () => {
+    const { container } = render(<TutorDialogModal {...defaultProps} />);
+
+    // DialogActions should not be in the DOM when no actions provided
+    const dialogActions = container.querySelector('.MuiDialogActions-root');
+    expect(dialogActions).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12 unit tests for UI components (AvatarImg and TutorDialogModal)
- Tests cover image rendering, size/direction props, fallback handling, dialog behavior
- All 90 unit tests now passing

## Test plan
- [x] Run `npm test` in frontend/ to verify all tests pass
- [x] Verify AvatarImg handles invalid avatar IDs gracefully
- [x] Verify TutorDialogModal renders and closes correctly

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)