### PR TITLE
fix: resolve frontend linting violations (#60)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,9 @@ repos:
     hooks:
       - id: eslint
         name: ESLint (JS/TS linter)
-        entry: bash -c 'source ~/.nvm/nvm.sh && nvm use 20 && npx eslint --fix'
+        entry: bash -c 'source ~/.nvm/nvm.sh && nvm use 20 && cd frontend && npx eslint --fix "${@#frontend/}"'
         language: system
-        types_or: [javascript, jsx, ts, tsx]
+        files: ^frontend/.*\.(js|jsx|ts|tsx)$
         pass_filenames: true
 
   # CSS/SCSS linting
@@ -28,9 +28,9 @@ repos:
     hooks:
       - id: stylelint
         name: Stylelint (CSS/SCSS linter)
-        entry: bash -c 'source ~/.nvm/nvm.sh && nvm use 20 && npx stylelint --fix'
+        entry: bash -c 'source ~/.nvm/nvm.sh && nvm use 20 && cd frontend && npx stylelint --fix "${@#frontend/}"'
         language: system
-        types: [css, scss, sass]
+        files: ^frontend/.*\.(css|scss|sass)$
         pass_filenames: true
 
   # General checks

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,10 +3,18 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  // Global ignores for vendor and generated files
+  {
+    ignores: [
+      'dist/**',
+      'coverage/**',
+      'public/static/admin/**',
+      'node_modules/**',
+      '*.min.js',
+    ],
+  },
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -17,7 +25,40 @@ export default tseslint.config([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        // Vitest globals
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+        vi: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+      },
+    },
+    rules: {
+      // Moderate strictness - catch real issues without being overly opinionated
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'no-debugger': 'error',
+
+      // React hooks rules (already from recommended, but explicit for clarity)
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+  // Relaxed rules for test files
+  {
+    files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}', 'tests/**/*'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-console': 'off',
     },
   },
 ])

--- a/frontend/src/app/pages/dashboard/LlmList.tsx
+++ b/frontend/src/app/pages/dashboard/LlmList.tsx
@@ -7,7 +7,7 @@ import {
 import {Button} from "@mui/material";
 
 
-const LlmList = ({}) => {
+const LlmList = () => {
     const chatId = "0f7b0766-b99e-4a16-8ed0-1922bb8680d7";
     const models = useGetModelsQuery({});
     const chats = useGetChatsQuery({});

--- a/frontend/src/app/store/localStorage.ts
+++ b/frontend/src/app/store/localStorage.ts
@@ -6,16 +6,16 @@ export const loadState = () => {
             return undefined;
         }
         return JSON.parse(serialState);
-    } catch (err) {
+    } catch {
         return undefined;
     }
 };
 
-export const saveState = (state: any) => {
+export const saveState = (state: unknown) => {
     try {
         const serialState = JSON.stringify(state);
         localStorage.setItem('appState', serialState);
     } catch(err) {
-        console.log(err);
+        console.error(err);
     }
 };

--- a/frontend/src/app/types/Conversation.ts
+++ b/frontend/src/app/types/Conversation.ts
@@ -11,7 +11,7 @@ export interface Chat {
         id: string;
         title: string;
         models: string[];
-        params: Record<string, any>;
+        params: Record<string, unknown>;
         history: {
             messages: Record<string, {
                 id: string;
@@ -23,14 +23,14 @@ export interface Chat {
                 model?: string;
                 modelName?: string;
                 modelIdx?: number;
-                userContext?: any;
+                userContext?: unknown;
                 lastSentence?: string;
                 usage?: {
                     prompt_tokens: number;
                     completion_tokens: number;
                     total_tokens: number;
-                    prompt_tokens_details?: any;
-                    completion_tokens_details?: any;
+                    prompt_tokens_details?: unknown;
+                    completion_tokens_details?: unknown;
                 };
                 done?: boolean;
             }>;
@@ -39,7 +39,7 @@ export interface Chat {
         messages: ChatMessage[];
         tags: string[];
         timestamp: number;
-        files: any[];
+        files: unknown[];
         model: string;
     };
     updated_at: number;

--- a/frontend/tests/e2e/chat-interaction.spec.ts
+++ b/frontend/tests/e2e/chat-interaction.spec.ts
@@ -99,7 +99,7 @@ test.describe('Chat Interaction', () => {
     await createNewChat(page);
 
     // Get the current URL (contains chat ID)
-    const chatUrl = page.url();
+    const _chatUrl = page.url();
 
     // Send a message
     const testMessage = 'Test message for persistence';

--- a/frontend/tests/e2e/chat-list.spec.ts
+++ b/frontend/tests/e2e/chat-list.spec.ts
@@ -23,7 +23,7 @@ test.describe('Chat List', () => {
   }
 
   // Helper to create a chat for testing
-  async function createTestChat(page: typeof import('@playwright/test').Page.prototype) {
+  async function _createTestChat(page: typeof import('@playwright/test').Page.prototype) {
     await page.goto('/chat-instructions/unit1_conversation1');
     await page.getByRole('button', { name: 'Start Chat' }).click();
     await expect(page).toHaveURL(/\/chat\/\d+/, { timeout: 15000 });

--- a/frontend/tests/e2e/onboarding.spec.ts
+++ b/frontend/tests/e2e/onboarding.spec.ts
@@ -12,7 +12,7 @@ test.describe('Onboarding', () => {
   }
 
   // Helper to clear seen dialogs from localStorage
-  async function clearSeenDialogs(page: typeof import('@playwright/test').Page.prototype) {
+  async function _clearSeenDialogs(page: typeof import('@playwright/test').Page.prototype) {
     await page.evaluate(() => {
       // Clear redux-persist state to reset seen dialogs
       const persistKey = 'persist:root';

--- a/frontend/tests/unit/store/preferences.slice.test.ts
+++ b/frontend/tests/unit/store/preferences.slice.test.ts
@@ -112,7 +112,7 @@ describe('preferences slice selectors', () => {
       userAvatarId: '7',
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     expect(getUserAvatarId(state as any)).toBe('7');
   });
 
@@ -122,7 +122,7 @@ describe('preferences slice selectors', () => {
       userAvatarId: '1',
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const avatar = getUserAvatar(state as any);
 
     expect(avatar).toBeDefined();
@@ -136,7 +136,7 @@ describe('preferences slice selectors', () => {
       apiToken: 'my-api-token',
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     expect(getApiToken(state as any)).toBe('my-api-token');
   });
 
@@ -146,7 +146,7 @@ describe('preferences slice selectors', () => {
       refreshToken: 'my-refresh-token',
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     expect(getRefreshToken(state as any)).toBe('my-refresh-token');
   });
 
@@ -156,7 +156,7 @@ describe('preferences slice selectors', () => {
       seenDialogs: { welcome: true, intro: false },
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const dialogs = getSeenDialogs(state as any);
 
     expect(dialogs.welcome).toBe(true);
@@ -170,7 +170,7 @@ describe('preferences slice selectors', () => {
       chatSettings,
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     expect(getChatSettings(state as any)).toEqual(chatSettings);
   });
 });


### PR DESCRIPTION
## Summary

- Updated ESLint config with proper ignores for vendor/generated files (dist, coverage, public/static/admin)
- Added Vitest globals (describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll)
- Added stricter TypeScript rules: no-explicit-any, no-unused-vars with underscore pattern
- Relaxed rules for test files (*.test.ts, *.spec.ts)
- Fixed empty object pattern in LlmList.tsx
- Replaced `any` types with `unknown` in Conversation.ts and localStorage.ts
- Prefixed unused test helper variables with underscore
- Removed unused eslint-disable directives
- Fixed pre-commit hooks to run ESLint/Stylelint from frontend directory

## Test plan

- [x] All 90 frontend unit tests pass
- [x] ESLint shows 0 errors, only warnings (debug console statements)
- [x] Pre-commit hooks pass

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)